### PR TITLE
fix remove Duration.Round to compatible with version less than go1.9

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -114,7 +114,7 @@ func (p *ProgressBar) Show() error {
 		strings.Repeat(p.symbolFinished, p.currentSaucerSize),
 		strings.Repeat(p.symbolLeft, p.size-p.currentSaucerSize),
 		p.rightBookend,
-		time.Since(p.startTime).Round(time.Second).String(),
+		(time.Duration(time.Since(p.startTime).Seconds()) * time.Second).String(),
 		(time.Duration(secondsLeft) * time.Second).String(),
 	)
 


### PR DESCRIPTION
see [Go 1.9 Release Notes](https://golang.org/doc/go1.9)

Duration.Round only supported in go1.9