### PR TITLE
Adding the option to render the bar, before calling Add()

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -26,67 +26,73 @@ type ProgressBar struct {
 
 	theme []string
 
-	sync.RWMutex
+	lock sync.RWMutex
 }
 
 func (p *ProgressBar) SetTheme(theme []string) {
-	p.Lock()
-	defer p.Unlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.theme = theme
 }
 
 // New returns a new ProgressBar
 // with the specified maximum
 func New(max int) *ProgressBar {
+	now := time.Now()
 	return &ProgressBar{
 		max:       max,
 		size:      40,
 		theme:     []string{"█", " ", "|", "|"},
 		w:         os.Stdout,
-		lastShown: time.Now(),
-		startTime: time.Now(),
+		lastShown: now,
+		startTime: now,
 	}
 }
 
-func (p ProgressBar) RenderBlank() {
-	renderProgressBar(p)
+func (p ProgressBar) RenderBlank() error {
+	return renderProgressBar(p)
 }
 
 // Reset will reset the clock that is used
 // to calculate current time and the time left.
 func (p *ProgressBar) Reset() {
-	p.Lock()
-	defer p.Unlock()
-	p.lastShown = time.Now()
-	p.startTime = time.Now()
-	p.currentNum = 0
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	pN := New(p.max)
+	pN.size = p.size
+	pN.theme = p.theme
+	pN.w = p.w
+	pN.lock = p.lock
+
+	*p = *pN
 }
 
 // SetMax sets the total number of the progress bar
 func (p *ProgressBar) SetMax(num int) {
-	p.Lock()
-	defer p.Unlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.max = num
 }
 
 // SetSize sets the size of the progress bar.
 func (p *ProgressBar) SetSize(size int) {
-	p.Lock()
-	defer p.Unlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.size = size
 }
 
 // SetWriter will specify a different writer than os.Stdout
 func (p *ProgressBar) SetWriter(w io.Writer) {
-	p.Lock()
-	defer p.Unlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.w = w
 }
 
 // Add with increase the current count on the progress bar
 func (p *ProgressBar) Add(num int) error {
-	p.Lock()
-	defer p.Unlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	if p.max == 0 {
 		return errors.New("max must be greater than 0")
 	}
@@ -109,7 +115,11 @@ func (p *ProgressBar) Add(num int) error {
 }
 
 func renderProgressBar(p ProgressBar) error {
-	leftTime := time.Since(p.startTime).Seconds() / float64(p.currentNum) * (float64(p.max) - float64(p.currentNum))
+	var leftTime float64
+	if p.currentNum > 0 {
+		leftTime = time.Since(p.startTime).Seconds() / float64(p.currentNum) * (float64(p.max) - float64(p.currentNum))
+	}
+
 	s := fmt.Sprintf("\r%4d%% %s%s%s%s [%s:%s]            ",
 		p.currentPercent,
 		p.theme[2],

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -30,6 +30,9 @@ func TestBar(t *testing.T) {
 func ExampleProgressBar_RenderBlank() {
 	bar := New(10)
 	bar.SetSize(10)
+	bar.Add(5)
+	bar.Reset()
+
 	bar.RenderBlank()
 	// Output:
 	// 0% |          | [0s:0s]

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -30,8 +30,6 @@ func TestBar(t *testing.T) {
 func ExampleProgressBar_RenderBlank() {
 	bar := New(10)
 	bar.SetSize(10)
-	bar.Add(5)
-	bar.Reset()
 
 	bar.RenderBlank()
 	// Output:

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -26,3 +26,11 @@ func TestBar(t *testing.T) {
 		t.Error("should have an error for adding > bar")
 	}
 }
+
+func ExampleProgressBar_RenderBlank() {
+	bar := New(10)
+	bar.SetSize(10)
+	bar.RenderBlank()
+	// Output:
+	// 0% |          | [0s:0s]
+}


### PR DESCRIPTION
I've introduced a new function to call to render the blank bar. I've refrained from adding it as an option, since the current API doesn't easily allow for setting options. I've also refrained from adding it by default as I didn't wanted to introduce a backwards incompatible change.


```go

b := progressbar.New(10)
b.RenderBlank()
ticker := time.NewTicker(1 * time.Second)
now := time.Now()
for t := range ticker.C {
	b.Add(1)
	if t.Sub(now).Seconds() >= 10 {
		break
	}
}

ticker.Stop()
```