### PR TITLE
Allow custom it/s string.

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -57,6 +57,7 @@ type config struct {
 	theme                Theme
 	renderWithBlankState bool
 	description          string
+	iterationString      string
 	ignoreLength         bool // ignoreLength if max bytes not known
 
 	// whether the output is expected to contain color codes
@@ -178,6 +179,13 @@ func OptionShowIts() Option {
 	}
 }
 
+// OptionSetItsString sets what's displayed for interations a second. The default is "it" which would display: "it/s"
+func OptionSetItsString(iterationString string) Option {
+	return func(p *ProgressBar) {
+		p.config.iterationString = iterationString
+	}
+}
+
 // OptionThrottle will wait the specified duration before updating again. The default
 // duration is 0 seconds.
 func OptionThrottle(duration time.Duration) Option {
@@ -222,6 +230,7 @@ func NewOptions64(max int64, options ...Option) *ProgressBar {
 		config: config{
 			writer:           os.Stdout,
 			theme:            defaultTheme,
+			iterationString:  "it",
 			width:            40,
 			max:              max,
 			throttleDuration: 0 * time.Nanosecond,
@@ -571,9 +580,9 @@ func renderProgressBar(c config, s state) (int, error) {
 			bytesString += ", "
 		}
 		if averageRate > 1 {
-			bytesString += fmt.Sprintf("%0.0f it/s", averageRate)
+			bytesString += fmt.Sprintf("%0.0f %s/s", averageRate, c.iterationString)
 		} else {
-			bytesString += fmt.Sprintf("%0.0f it/min", 60*averageRate)
+			bytesString += fmt.Sprintf("%0.0f %s/min", 60*averageRate, c.iterationString)
 		}
 	}
 	if bytesString != "" {

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -434,6 +434,25 @@ func TestConcurrency(t *testing.T) {
 	assert.Equal(t, expect, result)
 }
 
+func TestIterationNames(t *testing.T) {
+
+	b := Default(20)
+	tc := b.config
+
+	// Checking for the default iterations per second or "it/s"
+	if tc.iterationString != "it" {
+		t.Errorf("Expected %s to be %s, instead I got %s", "iterationString", "it", tc.iterationString)
+	}
+
+	// Change the default "it/s" to provide context, downloads per second or "dl/s"
+	b = NewOptions(20, OptionSetItsString("dl"))
+	tc = b.config
+
+	if tc.iterationString != "dl" {
+		t.Errorf("Expected %s to be %s, instead I got %s", "iterationString", "dl", tc.iterationString)
+	}
+}
+
 func md5sum(r io.Reader) (string, error) {
 	hash := md5.New()
 	_, err := io.Copy(hash, r)


### PR DESCRIPTION
The ability to display iterations per second in the progress bar is great but generic. I'd like to be able to customize that string to make it refer to whatever thing I'm actually doing. For examples, downloads per second or renders per second.

This PR enables a custom string to be used for it/s.

I implemented it as its own option in order to maintain backwards compatibility. Ideally it would be been a parameter for OptionShowIts() to keep things simple.

I also added a test to verify the original functionality as well as the new custom string.