### PR TITLE
Prevent changing current maximum on Finish

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -398,10 +398,12 @@ func (p *ProgressBar) Add64(num int64) error {
 		return errors.New("max must be greater than 0")
 	}
 
-	if p.config.ignoreLength {
-		p.state.currentNum = (p.state.currentNum + num) % p.config.max
-	} else {
-		p.state.currentNum += num
+	if p.state.currentNum < p.config.max {
+		if p.config.ignoreLength {
+			p.state.currentNum = (p.state.currentNum + num) % p.config.max
+		} else {
+			p.state.currentNum += num
+		}
 	}
 
 	p.state.currentBytes += float64(num)


### PR DESCRIPTION
Finish will set the `p.state.currentNum` to `p.config.max`:
```go
// Finish will fill the bar to full
func (p *ProgressBar) Finish() error {
	p.lock.Lock()
	p.state.currentNum = p.config.max
	p.lock.Unlock()
	return p.Add(0)
}
```

 Then, it calls `Add()`, which however alters the `p.state.currentNum`:
```go
		if p.config.ignoreLength {
			p.state.currentNum = (p.state.currentNum + num) % p.config.max
		} else {
			p.state.currentNum += num
		}
```

For spinners, this will cause the bar to never reach `p.config.max`, so the `p.config.onCompletion` will never be called in `render()`:
```go
	// check if the progress bar is finished
	if !p.state.finished && p.state.currentNum >= p.config.max {
		p.state.finished = true
		if !p.config.clearOnFinish {
			renderProgressBar(p.config, p.state)
		}

		if p.config.onCompletion != nil {
			p.config.onCompletion()
		}
	}
```

This PR fixes the issue by checking if the `p.config.max` is reached, and it doesn't alternate the current if yes.