### PR TITLE
try to get stderr width if stdout is not a terminal

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -655,7 +655,10 @@ func renderProgressBar(c config, s state) (int, error) {
 	if c.fullWidth && !c.ignoreLength {
 		width, _, err := terminal.GetSize(int(os.Stdout.Fd()))
 		if err != nil {
-			width = 80
+			width, _, err = terminal.GetSize(int(os.Stderr.Fd()))
+			if err != nil {
+				width = 80
+			}
 		}
 
 		c.width = width - len(c.description) - 14 - len(bytesString) - len(leftBrac) - len(rightBrac)


### PR DESCRIPTION
with the progressbar writing to stderr, when redirecting stdout to a file, the progressbar wasn't stretching to the whole line, limited at 80 columns.