### PR TITLE
bug fix: spinner only show first few icons

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -712,7 +712,7 @@ func renderProgressBar(c config, s state) (int, error) {
 	}
 	if c.ignoreLength {
 		str = fmt.Sprintf("\r%s %s %s ",
-			spinners[c.spinnerType][int(math.Round(math.Mod(float64(time.Since(s.counterTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))],
+			spinners[c.spinnerType][int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))],
 			c.description,
 			bytesString,
 		)

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -167,7 +167,7 @@ func ExampleIgnoreLength_WithIteration() {
 	bar.Add(5)
 
 	// Output:
-	// |  (5/-, 5 it/s)
+	// -  (5/-, 5 it/s)
 }
 
 func TestSpinnerType(t *testing.T) {
@@ -231,7 +231,7 @@ func ExampleIgnoreLength_WithSpeed() {
 	bar.Add(11)
 
 	// Output:
-	// |  (0.011 kB/s)
+	// -  (0.011 kB/s)
 }
 
 func TestBarSlowAdd(t *testing.T) {


### PR DESCRIPTION
When max is set to `-1`, a spiner is printed. But only first few got displayed.

## How to reproduce

```go
bar := progressbar.NewOptions(-1,
	progressbar.OptionSetDescription("issue"),
	progressbar.OptionSetRenderBlankState(true),
	progressbar.OptionSpinnerType(15), // rolling a,b,c,d....
	progressbar.OptionClearOnFinish())
for !bar.IsFinished() {
	_ = bar.Add(1)
	println() // print on a dedicate line
	time.Sleep(100 * time.Millisecond)
}
```

Sample output:
```
a issue  
b issue  
c issue  
d issue  
e issue  
a issue  
b issue  
c issue  
d issue  
e issue  
a issue  
....
```

# Tests explanation

default spinner (which is No. 9) has four icons: `| / - \`, \
with original implementation, after 1 second, the `counterTime` is rolled back to now() by `Add64()`, and will take icon at index `(0 / 100) % 4 = 0`, that is `|`.
with this pull request, 1 second later it will take icon at index `(1000 / 100) % 4 = 2`, thus `-`.