### PR TITLE
ChangeMax64 did not work with OptionShowBytes

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -546,6 +546,11 @@ func (p *ProgressBar) ChangeMax(newMax int) {
 // to avoid casting
 func (p *ProgressBar) ChangeMax64(newMax int64) {
 	p.config.max = newMax
+
+	if p.config.showBytes {
+		p.config.maxHumanized, p.config.maxHumanizedSuffix = humanizeBytes(float64(p.config.max))
+	}
+
 	p.Add(0) // re-render
 }
 


### PR DESCRIPTION
Test code:
```
bar := progressbar.NewOptions64(1, progressbar.OptionShowBytes(true), progressbar.OptionShowCount())
bar.ChangeMax64(500000)
bar.Add(250)
```

Output:
`0% |                                        | (250 B/ 1B, 466.006 kB/s) [0s:0s]`

Expected output:
`0% |                                        | (250 B/488 kB, 466.006 kB/s) [0s:0s]`