### PR TITLE
Show elapsed time when no length is given

### DIFF
--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -168,7 +168,7 @@ func ExampleIgnoreLength_WithIteration() {
 	bar.Add(5)
 
 	// Output:
-	// -  (5/-, 5 it/s)
+	// -  (5/-, 5 it/s) [1s]
 }
 
 func TestSpinnerType(t *testing.T) {
@@ -232,7 +232,7 @@ func ExampleIgnoreLength_WithSpeed() {
 	bar.Add(11)
 
 	// Output:
-	// -  (11 B/s)
+	// -  (11 B/s) [1s]
 }
 
 func TestBarSlowAdd(t *testing.T) {
@@ -382,6 +382,24 @@ func TestOptionSetPredictTime(t *testing.T) {
 	if result != expect {
 		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
 	}
+}
+
+func TestOptionSetElapsedTime(t *testing.T) {
+	/*
+		IgnoreLength test with iteration count and iteration rate
+	*/
+	bar := NewOptions(-1,
+		OptionSetWidth(10),
+		OptionShowIts(),
+		OptionShowCount(),
+		OptionSetElapsedTime(false),
+	)
+	bar.Reset()
+	time.Sleep(1 * time.Second)
+	bar.Add(5)
+
+	// Output:
+	// -  (5/-, 5 it/s)
 }
 
 func TestIgnoreLength(t *testing.T) {


### PR DESCRIPTION
Currently, the elapsed time is not output if a progress bar is created with length 0. This PR adds the elapsed time to the end of the progress bar in a similar way to a standard progress bar.

This PR also adds `OptionSetElapsedTime` which allows for hiding the elapsed time.

Example:
```
(5/-, 5 it/s) [1s]
```

Let me know if this should be considered a breaking change. I could then change `elapsedTime` to default to `false`.

Thank you!