### PR TITLE
Revert PR #113

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -326,7 +326,7 @@ func DefaultBytes(maxBytes int64, description ...string) *ProgressBar {
 		OptionThrottle(65*time.Millisecond),
 		OptionShowCount(),
 		OptionOnCompletion(func() {
-			fmt.Printf("\n")
+			fmt.Fprint(os.Stderr, "\n")
 		}),
 		OptionSpinnerType(14),
 		OptionFullWidth(),
@@ -375,7 +375,7 @@ func Default(max int64, description ...string) *ProgressBar {
 		OptionShowCount(),
 		OptionShowIts(),
 		OptionOnCompletion(func() {
-			fmt.Printf("\n")
+			fmt.Fprint(os.Stderr, "\n")
 		}),
 		OptionSpinnerType(14),
 		OptionFullWidth(),


### PR DESCRIPTION
See my comment here: https://github.com/schollz/progressbar/issues/108#issuecomment-1189221700

The original PR is/was wrong in that it mixes up `os.Stdout` and `os.Stderr` which might appear to produce the correct behaviour until you use some shell redirection to send one of those two outputs somewhere other than the controlling terminal.

If the progress bar is writing to `os.Stderr` then that final newline should also be sent to the same destination; the code was originally correct.

This PR reverts the original commit made in #113 but before I did that, I updated the two tests that use `DefaultBytes()` to ensure that nothing ever gets written to `os.Stdout` by the progress bar code.  These tests obviously fail initially, but then pass with the reverted commit.