### PR TITLE
Use the existing humanize function to support GB/s rates

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -702,19 +702,15 @@ func renderProgressBar(c config, s *state) (int, error) {
 		}
 	}
 
-	// show rolling average rate in kB/sec or MB/sec
-	if c.showBytes {
+	// show rolling average rate
+	if c.showBytes && averageRate > 0 && !math.IsInf(averageRate, 1) {
 		if bytesString == "" {
 			bytesString += "("
 		} else {
 			bytesString += ", "
 		}
-		kbPerSecond := averageRate / 1024.0
-		if kbPerSecond > 1024.0 {
-			bytesString += fmt.Sprintf("%0.3f MB/s", kbPerSecond/1024.0)
-		} else if kbPerSecond > 0 {
-			bytesString += fmt.Sprintf("%0.3f kB/s", kbPerSecond)
-		}
+		currentHumanize, currentSuffix := humanizeBytes(averageRate)
+		bytesString += fmt.Sprintf("%s%s/s", currentHumanize, currentSuffix)
 	}
 
 	// show iterations rate
@@ -928,7 +924,7 @@ func humanizeBytes(s float64) (string, string) {
 	sizes := []string{" B", " kB", " MB", " GB", " TB", " PB", " EB"}
 	base := 1024.0
 	if s < 10 {
-		return fmt.Sprintf("%2.0f", s), "B"
+		return fmt.Sprintf("%2.0f", s), sizes[0]
 	}
 	e := math.Floor(logn(float64(s), base))
 	suffix := sizes[int(e)]

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -233,7 +233,7 @@ func ExampleIgnoreLength_WithSpeed() {
 	bar.Add(11)
 
 	// Output:
-	// -  (0.011 kB/s)
+	// -  (11 B/s)
 }
 
 func TestBarSlowAdd(t *testing.T) {
@@ -270,6 +270,16 @@ func TestBarSmallBytes(t *testing.T) {
 		bar.Add(1000000)
 	}
 	if !strings.Contains(buf.String(), "8.6/95 MB") {
+		t.Errorf("wrong string: %s", buf.String())
+	}
+}
+
+func TestBarFastBytes(t *testing.T) {
+	buf := strings.Builder{}
+	bar := NewOptions64(1e8, OptionShowBytes(true), OptionShowCount(), OptionSetWidth(10), OptionSetWriter(&buf))
+	time.Sleep(time.Millisecond)
+	bar.Add(1e7)
+	if !strings.Contains(buf.String(), " GB/s)") {
 		t.Errorf("wrong string: %s", buf.String())
 	}
 }


### PR DESCRIPTION
I'd like to support both B/s and GB/s file rates as well. This PR uses the existing `humanizeBytes` function when formatting `averateRate` instead of just hard coding kB and MB.