### PR TITLE
Remove superfluous carriage returns

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -839,6 +839,9 @@ func renderProgressBar(c config, s *state) (int, error) {
 }
 
 func clearProgressBar(c config, s state) error {
+	if s.maxLineWidth == 0 {
+		return nil
+	}
 	if c.useANSICodes {
 		// write the "clear current line" ANSI escape sequence
 		return writeString(c, "\033[2K\r")
@@ -846,7 +849,7 @@ func clearProgressBar(c config, s state) error {
 	// fill the empty content
 	// to overwrite the progress bar and jump
 	// back to the beginning of the line
-	str := fmt.Sprintf("\r%s\r", strings.Repeat(" ", s.maxLineWidth))
+	str := fmt.Sprintf("\r%s", strings.Repeat(" ", s.maxLineWidth))
 	return writeString(c, str)
 	// the following does not show correctly if the previous line is longer than subsequent line
 	// return writeString(c, "\r")

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -579,7 +579,7 @@ func TestProgressBar_Describe(t *testing.T) {
 	bar.Describe("performing axial adjustments")
 	bar.Add(10)
 	rawBuf := strconv.QuoteToASCII(buf.String())
-	if rawBuf != `"\r\r\rperforming axial adjustments   0% |          |  [0s:0s]\r                                                       \r\rperforming axial adjustments  10% |\u2588         |  [0s:0s]"` {
+	if rawBuf != `"\rperforming axial adjustments   0% |          |  [0s:0s]\r                                                       \rperforming axial adjustments  10% |\u2588         |  [0s:0s]"` {
 		t.Errorf("wrong string: %s", rawBuf)
 	}
 }


### PR DESCRIPTION
Bit of a micro-optimization but I noticed that `clearProgressBar` was causing triple `\r` to be emitted unnecessarily.