### PR TITLE
feat!: use generics for new progressbar creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.19'
     - run: go version
     - run: go test -v -cover .

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # progressbar
 
 [![CI](https://github.com/schollz/progressbar/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/schollz/progressbar/actions/workflows/ci.yml)
-[![go report card](https://goreportcard.com/badge/github.com/schollz/progressbar)](https://goreportcard.com/report/github.com/schollz/progressbar) 
+[![go report card](https://goreportcard.com/badge/github.com/schollz/progressbar)](https://goreportcard.com/report/github.com/schollz/progressbar)
 [![coverage](https://img.shields.io/badge/coverage-84%25-brightgreen.svg)](https://gocover.io/github.com/schollz/progressbar)
-[![godocs](https://godoc.org/github.com/schollz/progressbar?status.svg)](https://godoc.org/github.com/schollz/progressbar/v3) 
+[![godocs](https://godoc.org/github.com/schollz/progressbar?status.svg)](https://godoc.org/github.com/schollz/progressbar/v3)
 
 A very simple thread-safe progress bar which should work on every OS without problems. I needed a progressbar for [croc](https://github.com/schollz/croc) and everything I tried had problems, so I made another one. In order to be OS agnostic I do not plan to support [multi-line outputs](https://github.com/schollz/progressbar/issues/6).
 
+## Requires
+
+Progressbar V4 requires Go version v1.18 or later.
 
 ## Install
 
@@ -14,7 +17,7 @@ A very simple thread-safe progress bar which should work on every OS without pro
 go get -u github.com/schollz/progressbar/v3
 ```
 
-## Usage 
+## Usage
 
 ### Basic usage
 

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/schollz/progressbar/v3"
+	"github.com/schollz/progressbar/v4"
 )
 
 func main() {

--- a/examples/customization/main.go
+++ b/examples/customization/main.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/k0kubun/go-ansi"
-	"github.com/schollz/progressbar/v3"
+	"github.com/schollz/progressbar/v4"
 )
 
 func main() {

--- a/examples/download-unknown/main.go
+++ b/examples/download-unknown/main.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/schollz/progressbar/v3"
+	"github.com/schollz/progressbar/v4"
 )
 
 func main() {

--- a/examples/download/main.go
+++ b/examples/download/main.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/schollz/progressbar/v3"
+	"github.com/schollz/progressbar/v4"
 )
 
 func main() {

--- a/examples/pacman/main.go
+++ b/examples/pacman/main.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/k0kubun/go-ansi"
-	"github.com/schollz/progressbar/v3"
+	"github.com/schollz/progressbar/v4"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,19 @@
 module github.com/schollz/progressbar/v3
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
-	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )
 
-go 1.13
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
+)
+
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/schollz/progressbar/v3
+module github.com/schollz/progressbar/v4
 
 require (
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 h1:XDXtA5hveEEV8JB2l7nhMTp3t3cHp9ZpwcdjqyEWLlo=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/progressbar.go
+++ b/progressbar.go
@@ -260,12 +260,7 @@ func OptionUseANSICodes(val bool) Option {
 var defaultTheme = Theme{Saucer: "█", SaucerPadding: " ", BarStart: "|", BarEnd: "|"}
 
 // NewOptions constructs a new instance of ProgressBar, with any options you specify
-func NewOptions(max int, options ...Option) *ProgressBar {
-	return NewOptions64(int64(max), options...)
-}
-
-// NewOptions64 constructs a new instance of ProgressBar, with any options you specify
-func NewOptions64(max int64, options ...Option) *ProgressBar {
+func NewOptions[V int | int64](max V, options ...Option) *ProgressBar {
 	b := ProgressBar{
 		state: getBasicState(),
 		config: config{
@@ -273,7 +268,7 @@ func NewOptions64(max int64, options ...Option) *ProgressBar {
 			theme:            defaultTheme,
 			iterationString:  "it",
 			width:            40,
-			max:              max,
+			max:              int64(max),
 			throttleDuration: 0 * time.Nanosecond,
 			elapsedTime:      true,
 			predictTime:      true,
@@ -317,19 +312,19 @@ func getBasicState() state {
 
 // New returns a new ProgressBar
 // with the specified maximum
-func New(max int) *ProgressBar {
+func New[V int | int64](max V) *ProgressBar {
 	return NewOptions(max)
 }
 
 // DefaultBytes provides a progressbar to measure byte
 // throughput with recommended defaults.
 // Set maxBytes to -1 to use as a spinner.
-func DefaultBytes(maxBytes int64, description ...string) *ProgressBar {
+func DefaultBytes[V int | int64](maxBytes V, description ...string) *ProgressBar {
 	desc := ""
 	if len(description) > 0 {
 		desc = description[0]
 	}
-	return NewOptions64(
+	return NewOptions(
 		maxBytes,
 		OptionSetDescription(desc),
 		OptionSetWriter(os.Stderr),
@@ -348,14 +343,14 @@ func DefaultBytes(maxBytes int64, description ...string) *ProgressBar {
 
 // DefaultBytesSilent is the same as DefaultBytes, but does not output anywhere.
 // String() can be used to get the output instead.
-func DefaultBytesSilent(maxBytes int64, description ...string) *ProgressBar {
+func DefaultBytesSilent[V int | int64](maxBytes V, description ...string) *ProgressBar {
 	// Mostly the same bar as DefaultBytes
 
 	desc := ""
 	if len(description) > 0 {
 		desc = description[0]
 	}
-	return NewOptions64(
+	return NewOptions(
 		maxBytes,
 		OptionSetDescription(desc),
 		OptionSetWriter(ioutil.Discard),
@@ -370,12 +365,12 @@ func DefaultBytesSilent(maxBytes int64, description ...string) *ProgressBar {
 
 // Default provides a progressbar with recommended defaults.
 // Set max to -1 to use as a spinner.
-func Default(max int64, description ...string) *ProgressBar {
+func Default[V int | int64](max V, description ...string) *ProgressBar {
 	desc := ""
 	if len(description) > 0 {
 		desc = description[0]
 	}
-	return NewOptions64(
+	return NewOptions(
 		max,
 		OptionSetDescription(desc),
 		OptionSetWriter(os.Stderr),
@@ -394,14 +389,14 @@ func Default(max int64, description ...string) *ProgressBar {
 
 // DefaultSilent is the same as Default, but does not output anywhere.
 // String() can be used to get the output instead.
-func DefaultSilent(max int64, description ...string) *ProgressBar {
+func DefaultSilent[V int | int64](max V, description ...string) *ProgressBar {
 	// Mostly the same bar as Default
 
 	desc := ""
 	if len(description) > 0 {
 		desc = description[0]
 	}
-	return NewOptions64(
+	return NewOptions(
 		max,
 		OptionSetDescription(desc),
 		OptionSetWriter(ioutil.Discard),
@@ -530,12 +525,6 @@ func (p *ProgressBar) Describe(description string) {
 		return
 	}
 	p.render()
-}
-
-// New64 returns a new ProgressBar
-// with the specified maximum
-func New64(max int64) *ProgressBar {
-	return NewOptions64(max)
 }
 
 // GetMax returns the max of a bar

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func BenchmarkRender(b *testing.B) {
-	bar := NewOptions64(100000000,
+	bar := NewOptions(100000000,
 		OptionSetWriter(os.Stderr),
 		OptionShowIts(),
 	)
@@ -256,7 +256,7 @@ func TestBarSlowAdd(t *testing.T) {
 
 func TestBarSmallBytes(t *testing.T) {
 	buf := strings.Builder{}
-	bar := NewOptions64(100000000, OptionShowBytes(true), OptionShowCount(), OptionSetWidth(10), OptionSetWriter(&buf))
+	bar := NewOptions(100000000, OptionShowBytes(true), OptionShowCount(), OptionSetWidth(10), OptionSetWriter(&buf))
 	for i := 1; i < 10; i++ {
 		time.Sleep(100 * time.Millisecond)
 		bar.Add(1000)
@@ -275,7 +275,7 @@ func TestBarSmallBytes(t *testing.T) {
 
 func TestBarFastBytes(t *testing.T) {
 	buf := strings.Builder{}
-	bar := NewOptions64(1e8, OptionShowBytes(true), OptionShowCount(), OptionSetWidth(10), OptionSetWriter(&buf))
+	bar := NewOptions(int(1e8), OptionShowBytes(true), OptionShowCount(), OptionSetWidth(10), OptionSetWriter(&buf))
 	time.Sleep(time.Millisecond)
 	bar.Add(1e7)
 	if !strings.Contains(buf.String(), " GB/s)") {


### PR DESCRIPTION
Changes to allow either int or int64 when calling various 'New' methods to create new progressbar instances.

```go
items := make([]int, 999)
bar1 := progressbar.Default(len(items))
bar2 := progressbar.Default(int64(len(items)))
```

This is a breaking change as it requires Go v1.18 to make use of generics. May be worth stating this in the README above the installation title on v4 release.

````md
## Requires

Progressbar V4 requires Go version v1.18 or later.
````

Note: Can't make methods generics (i.e. those bound to structs, `ChangeMax`, `ChangeMax64` etc) due to limitations in current [generics implementation with Go](https://github.com/golang/go/issues/49085).

Resolves schollz/progressbar#129