### PR TITLE
feat: option to keep showing elapsed time on finish

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -80,6 +80,8 @@ type config struct {
 	// always enabled if predictTime is true.
 	elapsedTime bool
 
+	showElapsedTimeOnFinish bool
+
 	// whether the progress bar should attempt to predict the finishing
 	// time of the progress based on the start time and the average
 	// number of seconds between  increments.
@@ -211,7 +213,14 @@ func OptionShowIts() Option {
 	}
 }
 
-// OptionSetItsString sets what's displayed for interations a second. The default is "it" which would display: "it/s"
+// OptionShowElapsedOnFinish will keep the display of elapsed time on finish
+func OptionShowElapsedTimeOnFinish() Option {
+	return func(p *ProgressBar) {
+		p.config.showElapsedTimeOnFinish = true
+	}
+}
+
+// OptionSetItsString sets what's displayed for iterations a second. The default is "it" which would display: "it/s"
 func OptionSetItsString(iterationString string) Option {
 	return func(p *ProgressBar) {
 		p.config.iterationString = iterationString
@@ -837,6 +846,9 @@ func renderProgressBar(c config, s *state) (int, error) {
 				c.theme.BarEnd,
 				bytesString,
 			)
+			if c.showElapsedTimeOnFinish {
+				str = fmt.Sprintf("%s [%s]", str, leftBrac)
+			}
 		} else {
 			str = fmt.Sprintf("\r%s%4d%% %s%s%s%s %s [%s:%s]",
 				c.description,

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -402,6 +402,26 @@ func TestOptionSetElapsedTime(t *testing.T) {
 	// -  (5/-, 5 it/s)
 }
 
+func TestShowElapsedTimeOnFinish(t *testing.T) {
+	buf := strings.Builder{}
+	bar := NewOptions(10,
+		OptionShowElapsedTimeOnFinish(),
+		OptionSetWidth(10),
+		OptionSetWriter(&buf),
+	)
+
+	bar.Reset()
+	time.Sleep(3 * time.Second)
+	bar.Add(10)
+
+	result := strings.TrimSpace(buf.String())
+	expect := "100% |██████████|  [3s]"
+
+	if result != expect {
+		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
+	}
+}
+
 func TestIgnoreLength(t *testing.T) {
 	bar := NewOptions(
 		-1,


### PR DESCRIPTION
Add an option to keep the render of time elapsed when the bar has finished.

```go
bar := progressbar.NewOptions64(
	10,
)
// Output:
//  100% |████████████████████████████████████████|         

bar := progressbar.NewOptions64(
	10,
	progressbar.OptionShowElapsedTimeOnFinish(),
)
// Output:
//  100% |████████████████████████████████████████|  [10s]
```

Resolves schollz/progressbar#128