### PR TITLE
feat: on clear, correctly flush with carriage return

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -873,7 +873,7 @@ func clearProgressBar(c config, s state) error {
 	// fill the empty content
 	// to overwrite the progress bar and jump
 	// back to the beginning of the line
-	str := fmt.Sprintf("\r%s", strings.Repeat(" ", s.maxLineWidth))
+	str := fmt.Sprintf("\r%s\r", strings.Repeat(" ", s.maxLineWidth))
 	return writeString(c, str)
 	// the following does not show correctly if the previous line is longer than subsequent line
 	// return writeString(c, "\r")

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -606,7 +606,7 @@ func TestProgressBar_Describe(t *testing.T) {
 	bar.Describe("performing axial adjustments")
 	bar.Add(10)
 	rawBuf := strconv.QuoteToASCII(buf.String())
-	if rawBuf != `"\rperforming axial adjustments   0% |          |  [0s:0s]\r                                                       \rperforming axial adjustments  10% |\u2588         |  [0s:0s]"` {
+	if rawBuf != `"\rperforming axial adjustments   0% |          |  [0s:0s]\r                                                       \r\rperforming axial adjustments  10% |\u2588         |  [0s:0s]"` {
 		t.Errorf("wrong string: %s", rawBuf)
 	}
 }


### PR DESCRIPTION
Below comparison between examples/basic bar output and the output for code on issue schollz/progressbar#130 with the PR changes.

<img width="1403" alt="Screenshot 2022-09-01 at 12 32 47" src="https://user-images.githubusercontent.com/1098786/187904319-eed47df9-e372-4313-8904-191857a0463e.png">

Resolves schollz/progressbar#130
