### PR TITLE
#86 Add option to write description at end of line instead of begin of line

### DIFF
--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -136,6 +136,20 @@ func ExampleOptionSetPredictTime() {
 	// 10% |█         |
 }
 
+func ExampleOptionShowDescriptionAtLineEnd() {
+	bar := NewOptions(100, OptionSetWidth(10), OptionShowDescriptionAtLineEnd(), OptionSetDescription("hello"))
+	_ = bar.Add(10)
+	// Output:
+	// 10% |█         |  [0s:0s] hello
+}
+
+func ExampleOptionShowDescriptionAtLineEnd_WithSpinner() {
+	bar := NewOptions(-1, OptionSetWidth(10), OptionShowDescriptionAtLineEnd(), OptionSetDescription("hello"))
+	_ = bar.Add(1)
+	// Output:
+	// |  [0s] hello
+}
+
 func ExampleDefault() {
 	bar := Default(100)
 	for i := 0; i < 50; i++ {


### PR DESCRIPTION
This fixes #86 

Hi, I've added the flag `showDescriptionAtLineEnd` to the progress bar. I'm not sure, if I am happy with this naming, but it was the best that came into my mind. :)

The part starting at line 828 is quite cluttered now. I suggest, extracting a function with early returns, but I did not wanted to let this pull request getting too big. If you agree, I can create another pull request for this refactoring.