### PR TITLE
feat!: Add ability to use custom style for bytes showing

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -109,6 +109,7 @@ type config struct {
 
 	// showDescriptionAtLineEnd specifies whether description should be written at line end instead of line start
 	showDescriptionAtLineEnd bool
+	customByteShow           func(float64, int64) string
 }
 
 // Theme defines the elements of the bar
@@ -273,6 +274,13 @@ func OptionUseANSICodes(val bool) Option {
 func OptionShowDescriptionAtLineEnd() Option {
 	return func(p *ProgressBar) {
 		p.config.showDescriptionAtLineEnd = true
+	}
+}
+
+// OptionUseCustomBytesShow a transformation function that takes
+func OptionUseCustomBytesShow(option func(float64, int64) string) Option {
+	return func(p *ProgressBar) {
+		p.config.customByteShow = option
 	}
 }
 
@@ -724,6 +732,8 @@ func renderProgressBar(c config, s *state) (int, error) {
 				} else {
 					bytesString += fmt.Sprintf("%s%s/%s%s", currentHumanize, currentSuffix, c.maxHumanized, c.maxHumanizedSuffix)
 				}
+			} else if c.customByteShow != nil {
+				bytesString += c.customByteShow(s.currentBytes, c.max)
 			} else {
 				bytesString += fmt.Sprintf("%.0f/%d", s.currentBytes, c.max)
 			}
@@ -731,6 +741,8 @@ func renderProgressBar(c config, s *state) (int, error) {
 			if c.showBytes {
 				currentHumanize, currentSuffix := humanizeBytes(s.currentBytes)
 				bytesString += fmt.Sprintf("%s%s", currentHumanize, currentSuffix)
+			} else if c.customByteShow != nil {
+				bytesString += c.customByteShow(s.currentBytes, c.max)
 			} else {
 				bytesString += fmt.Sprintf("%.0f/%s", s.currentBytes, "-")
 			}

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -416,6 +416,38 @@ func TestOptionSetElapsedTime(t *testing.T) {
 	// -  (5/-, 5 it/s)
 }
 
+func ExampleOptionUseCustomBytesShow() {
+	bar := NewOptions(-1,
+		OptionSetWidth(10),
+		OptionShowIts(),
+		OptionShowCount(),
+		OptionSetElapsedTime(false), OptionUseCustomBytesShow(func(f float64, _ int64) string {
+			return fmt.Sprintf("%.0f items", f)
+		}))
+	bar.Reset()
+	time.Sleep(1 * time.Second)
+	bar.Add(5)
+
+	// Output:
+	// -  (5 items, 5 it/s)
+}
+
+func ExampleOptionUseCustomBytesShowWithMax() {
+	bar := NewOptions(100,
+		OptionSetWidth(10),
+		OptionShowIts(),
+		OptionShowCount(),
+		OptionSetElapsedTime(false), OptionUseCustomBytesShow(func(f float64, i int64) string {
+			return fmt.Sprintf("%.0f of %d items", f, i)
+		}))
+	bar.Reset()
+	time.Sleep(1 * time.Second)
+	bar.Add(5)
+
+	// Output:
+	// -  (5 of 100 items, 5 it/s)
+}
+
 func TestShowElapsedTimeOnFinish(t *testing.T) {
 	buf := strings.Builder{}
 	bar := NewOptions(10,


### PR DESCRIPTION
I have added ability to customize way of bytes show by adding an option.

```
func ExampleOptionUseCustomBytesShowWithMax() {
	bar := NewOptions(100,
		OptionSetWidth(10),
		OptionShowIts(),
		OptionShowCount(),
		OptionSetElapsedTime(false), OptionUseCustomBytesShow(func(f float64, i int64) string {
			return fmt.Sprintf("%.0f of %d items", f, i)
		}))
	bar.Reset()
	time.Sleep(1 * time.Second)
	bar.Add(5)

	// Output:
	// -  (5 of 100 items, 5 it/s)
}
```

closes #138 