### PR TITLE
Fixes case where bar was being incorrectly cleared on finished #75

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -625,7 +625,7 @@ func (p *ProgressBar) render() error {
 	}
 	if p.state.finished {
 		// when using ANSI codes we don't pre-clean the current line
-		if p.config.useANSICodes {
+		if p.config.useANSICodes && p.config.clearOnFinish {
 			err := clearProgressBar(p.config, p.state)
 			if err != nil {
 				return err


### PR DESCRIPTION
Issue #75 

Bar was incorrectly being cleared when p.config.useANSICodes == true, but p.config.clearOnFinish == false.
