### PR TITLE
Fix full width test

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -188,7 +188,7 @@ func OptionEnableColorCodes(colorCodes bool) Option {
 	}
 }
 
-// OptionSetElapsedTime will enable elapsed time. always enabled if OptionSetPredictTime is true.
+// OptionSetElapsedTime will enable elapsed time. Always enabled if OptionSetPredictTime is true.
 func OptionSetElapsedTime(elapsedTime bool) Option {
 	return func(p *ProgressBar) {
 		p.config.elapsedTime = elapsedTime
@@ -484,12 +484,12 @@ func (p *ProgressBar) Add(num int) error {
 	return p.Add64(int64(num))
 }
 
-// Set wil set the bar to a current number
+// Set will set the bar to a current number
 func (p *ProgressBar) Set(num int) error {
 	return p.Set64(int64(num))
 }
 
-// Set64 wil set the bar to a current number
+// Set64 will set the bar to a current number
 func (p *ProgressBar) Set64(num int64) error {
 	p.lock.Lock()
 	toAdd := num - int64(p.state.currentBytes)
@@ -795,12 +795,9 @@ func renderProgressBar(c config, s *state) (int, error) {
 	}
 
 	if c.fullWidth && !c.ignoreLength {
-		width, _, err := term.GetSize(int(os.Stdout.Fd()))
+		width, err := termWidth()
 		if err != nil {
-			width, _, err = term.GetSize(int(os.Stderr.Fd()))
-			if err != nil {
-				width = 80
-			}
+			width = 80
 		}
 
 		amend := 1 // an extra space at eol
@@ -1061,4 +1058,18 @@ func humanizeBytes(s float64) (string, string) {
 
 func logn(n, b float64) float64 {
 	return math.Log(n) / math.Log(b)
+}
+
+// termWidth function returns the visible width of the current terminal
+// and can be redefined for testing
+var termWidth = func() (width int, err error) {
+	width, _, err = term.GetSize(int(os.Stdout.Fd()))
+	if err == nil {
+		return width, nil
+	}
+	width, _, err = term.GetSize(int(os.Stderr.Fd()))
+	if err == nil {
+		return width, nil
+	}
+	return 0, err
 }

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -16,6 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMain(m *testing.M) {
+	termWidth = func() (int, error) {
+		return 0, os.ErrPermission
+	}
+	os.Exit(m.Run())
+}
+
 func BenchmarkRender(b *testing.B) {
 	bar := NewOptions64(100000000,
 		OptionSetWriter(os.Stderr),

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -395,12 +395,11 @@ func TestOptionSetPredictTime(t *testing.T) {
 	}
 }
 
-func TestOptionSetElapsedTime(t *testing.T) {
-	/*
-		Spinner test with iteration count and iteration rate
-	*/
+func TestOptionSetElapsedTime_spinner(t *testing.T) {
+	buf := strings.Builder{}
 	bar := NewOptions(-1,
 		OptionSetWidth(10),
+		OptionSetWriter(&buf),
 		OptionShowIts(),
 		OptionShowCount(),
 		OptionSetElapsedTime(false),
@@ -408,9 +407,11 @@ func TestOptionSetElapsedTime(t *testing.T) {
 	bar.Reset()
 	time.Sleep(1 * time.Second)
 	bar.Add(5)
-
-	// Output:
-	// -  (5/-, 5 it/s)
+	result := strings.TrimSpace(buf.String())
+	expect := "-  (5/-, 5 it/s)"
+	if result != expect {
+		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
+	}
 }
 
 func TestShowElapsedTimeOnFinish(t *testing.T) {
@@ -420,14 +421,11 @@ func TestShowElapsedTimeOnFinish(t *testing.T) {
 		OptionSetWidth(10),
 		OptionSetWriter(&buf),
 	)
-
 	bar.Reset()
 	time.Sleep(3 * time.Second)
 	bar.Add(10)
-
 	result := strings.TrimSpace(buf.String())
 	expect := "100% |██████████|  [3s]"
-
 	if result != expect {
 		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
 	}


### PR DESCRIPTION
I noticed that when running `go test -bench.` it handles stdout and stderr in some different way, so `term.GetSize()` manages to get the actual size of the current terminal and cause TestOptionFullWidth to fail, so here is the fix.

There was also another test that wasn't actually checking anything and I fixed that one as well.