### PR TITLE
fix(clearProgressBar):fix fill empty content

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -961,8 +961,8 @@ func clearProgressBar(c config, s state) error {
 	// fill the empty content
 	// to overwrite the progress bar and jump
 	// back to the beginning of the line
-	str := fmt.Sprintf("\r%s\r", strings.Repeat(" ", s.maxLineWidth))
-	return writeString(c, str)
+	//str := fmt.Sprintf("\r%s\r", strings.Repeat(" ", s.maxLineWidth))
+	return writeString(c, "\r")
 	// the following does not show correctly if the previous line is longer than subsequent line
 	// return writeString(c, "\r")
 }


### PR DESCRIPTION
When filling in empty content, I understand that should jump back to the beginning.In fact, it's a line break.