### PR TITLE
feature/allow-custom-spinners

### DIFF
--- a/examples/customization/main.go
+++ b/examples/customization/main.go
@@ -38,5 +38,5 @@ func main() {
 
 	// got notified that progress bar is complete.
 	<-doneCh
-	fmt.Println("\n ======= progress bar completed ==========\n")
+	fmt.Println("\n ======= progress bar completed ==========")
 }

--- a/examples/download/main.go
+++ b/examples/download/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -11,7 +12,7 @@ import (
 func main() {
 	req, _ := http.NewRequest("GET", "https://dl.google.com/go/go1.14.2.src.tar.gz", nil)
 	resp, _ := http.DefaultClient.Do(req)
-	defer resp.Body.Close()
+	defer check(resp.Body.Close)
 
 	f, _ := os.OpenFile("go1.14.2.src.tar.gz", os.O_CREATE|os.O_WRONLY, 0644)
 	defer f.Close()
@@ -21,4 +22,11 @@ func main() {
 		"downloading",
 	)
 	io.Copy(io.MultiWriter(f, bar), resp.Body)
+}
+
+// check checks the returned error of a function.
+func check(f func() error) {
+	if err := f(); err != nil {
+		fmt.Fprintf(os.Stderr, "received error: %v\n", err)
+	}
 }

--- a/examples/pacman/main.go
+++ b/examples/pacman/main.go
@@ -37,5 +37,5 @@ func main() {
 
 	// got notified that progress bar is complete.
 	<-doneCh
-	fmt.Println("\n ======= progress bar completed ==========\n")
+	fmt.Println("\n ======= progress bar completed ==========")
 }

--- a/progressbar.go
+++ b/progressbar.go
@@ -878,9 +878,6 @@ func renderProgressBar(c config, s *state) (int, error) {
 			selectedSpinner = c.spinner
 		}
 		spinner := selectedSpinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(selectedSpinner)))))]
-		if len(c.spinner) > 0 {
-			spinner = c.spinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(c.spinner)))))]
-		}
 		if c.elapsedTime {
 			if c.showDescriptionAtLineEnd {
 				str = fmt.Sprintf("\r%s %s [%s] %s ",

--- a/progressbar.go
+++ b/progressbar.go
@@ -873,9 +873,10 @@ func renderProgressBar(c config, s *state) (int, error) {
 	str := ""
 
 	if c.ignoreLength {
-		spinner := spinners[c.spinnerType][int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))]
+		index := int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))
+		spinner := spinners[c.spinnerType][index]
 		if len(c.spinner) > 0 {
-			spinner = c.spinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))]
+			spinner = c.spinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(c.spinner)))))]
 		}
 		if c.elapsedTime {
 			if c.showDescriptionAtLineEnd {

--- a/progressbar.go
+++ b/progressbar.go
@@ -873,8 +873,11 @@ func renderProgressBar(c config, s *state) (int, error) {
 	str := ""
 
 	if c.ignoreLength {
-		index := int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))
-		spinner := spinners[c.spinnerType][index]
+		selectedSpinner := spinners[c.spinnerType]
+		if len(c.spinner) > 0 {
+			selectedSpinner = c.spinner
+		}
+		spinner := selectedSpinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(selectedSpinner)))))]
 		if len(c.spinner) > 0 {
 			spinner = c.spinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(c.spinner)))))]
 		}

--- a/progressbar.go
+++ b/progressbar.go
@@ -96,6 +96,12 @@ type config struct {
 	// spinnerType should be a number between 0-75
 	spinnerType int
 
+	// spinnerTypeOptionUsed remembers if the spinnerType was changed manually
+	spinnerTypeOptionUsed bool
+
+	// spinner represents the spinner as a slice of string
+	spinner []string
+
 	// fullWidth specifies whether to measure and set the bar to a specific width
 	fullWidth bool
 
@@ -134,7 +140,16 @@ func OptionSetWidth(s int) Option {
 // OptionSpinnerType sets the type of spinner used for indeterminate bars
 func OptionSpinnerType(spinnerType int) Option {
 	return func(p *ProgressBar) {
+		p.config.spinnerTypeOptionUsed = true
 		p.config.spinnerType = spinnerType
+	}
+}
+
+// OptionSpinnerCustom sets the spinner used for indeterminate bars to the passed
+// slice of string
+func OptionSpinnerCustom(spinner []string) Option {
+	return func(p *ProgressBar) {
+		p.config.spinner = spinner
 	}
 }
 
@@ -509,6 +524,11 @@ func (p *ProgressBar) Add64(num int64) error {
 		return nil
 	}
 
+	// error out since OptionSpinnerCustom will always override a manually set spinnerType
+	if p.config.spinnerTypeOptionUsed && len(p.config.spinner) > 0 {
+		return errors.New("OptionSpinnerType and OptionSpinnerCustom cannot be used together")
+	}
+
 	if p.config.max == 0 {
 		return errors.New("max must be greater than 0")
 	}
@@ -854,6 +874,9 @@ func renderProgressBar(c config, s *state) (int, error) {
 
 	if c.ignoreLength {
 		spinner := spinners[c.spinnerType][int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))]
+		if len(c.spinner) > 0 {
+			spinner = c.spinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))]
+		}
 		if c.elapsedTime {
 			if c.showDescriptionAtLineEnd {
 				str = fmt.Sprintf("\r%s %s [%s] %s ",

--- a/progressbar.go
+++ b/progressbar.go
@@ -93,8 +93,8 @@ type config struct {
 	// clear bar once finished
 	clearOnFinish bool
 
-	// spinner is a slice of string to represent the animation
-	spinner []string
+	// spinnerType should be a number between 0-75
+	spinnerType int
 
 	// fullWidth specifies whether to measure and set the bar to a specific width
 	fullWidth bool
@@ -132,9 +132,9 @@ func OptionSetWidth(s int) Option {
 }
 
 // OptionSpinnerType sets the type of spinner used for indeterminate bars
-func OptionSpinnerType(spinner []string) Option {
+func OptionSpinnerType(spinnerType int) Option {
 	return func(p *ProgressBar) {
-		p.config.spinner = spinner
+		p.config.spinnerType = spinnerType
 	}
 }
 
@@ -296,13 +296,17 @@ func NewOptions64(max int64, options ...Option) *ProgressBar {
 			throttleDuration: 0 * time.Nanosecond,
 			elapsedTime:      true,
 			predictTime:      true,
-			spinner:          GetPresetSpinner(9),
+			spinnerType:      9,
 			invisible:        false,
 		},
 	}
 
 	for _, o := range options {
 		o(&b)
+	}
+
+	if b.config.spinnerType < 0 || b.config.spinnerType > 75 {
+		panic("invalid spinner type, must be between 0 and 75")
 	}
 
 	// ignoreLength if max bytes not known
@@ -355,7 +359,7 @@ func DefaultBytes(maxBytes int64, description ...string) *ProgressBar {
 		OptionOnCompletion(func() {
 			fmt.Fprint(os.Stderr, "\n")
 		}),
-		OptionSpinnerType(GetPresetSpinner(14)),
+		OptionSpinnerType(14),
 		OptionFullWidth(),
 		OptionSetRenderBlankState(true),
 	)
@@ -378,7 +382,7 @@ func DefaultBytesSilent(maxBytes int64, description ...string) *ProgressBar {
 		OptionSetWidth(10),
 		OptionThrottle(65*time.Millisecond),
 		OptionShowCount(),
-		OptionSpinnerType(GetPresetSpinner(14)),
+		OptionSpinnerType(14),
 		OptionFullWidth(),
 	)
 }
@@ -401,7 +405,7 @@ func Default(max int64, description ...string) *ProgressBar {
 		OptionOnCompletion(func() {
 			fmt.Fprint(os.Stderr, "\n")
 		}),
-		OptionSpinnerType(GetPresetSpinner(14)),
+		OptionSpinnerType(14),
 		OptionFullWidth(),
 		OptionSetRenderBlankState(true),
 	)
@@ -424,7 +428,7 @@ func DefaultSilent(max int64, description ...string) *ProgressBar {
 		OptionThrottle(65*time.Millisecond),
 		OptionShowCount(),
 		OptionShowIts(),
-		OptionSpinnerType(GetPresetSpinner(14)),
+		OptionSpinnerType(14),
 		OptionFullWidth(),
 	)
 }
@@ -849,7 +853,7 @@ func renderProgressBar(c config, s *state) (int, error) {
 	str := ""
 
 	if c.ignoreLength {
-		spinner := c.spinner[int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(c.spinner)))))]
+		spinner := spinners[c.spinnerType][int(math.Round(math.Mod(float64(time.Since(s.startTime).Milliseconds()/100), float64(len(spinners[c.spinnerType])))))]
 		if c.elapsedTime {
 			if c.showDescriptionAtLineEnd {
 				str = fmt.Sprintf("\r%s %s [%s] %s ",
@@ -1068,13 +1072,4 @@ var termWidth = func() (width int, err error) {
 		return width, nil
 	}
 	return 0, err
-}
-
-// GetPresetSpinner returns an preset spinner. The spinnerType is an integer
-// between 0 and 75.
-func GetPresetSpinner(spinnerType int) []string {
-	if spinnerType < 0 || spinnerType > 75 {
-		panic("invalid spinner type, must be between 0 and 75")
-	}
-	return spinners[spinnerType]
 }

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -196,7 +196,7 @@ func TestSpinnerType(t *testing.T) {
 		OptionSetDescription("indeterminate spinner"),
 		OptionShowIts(),
 		OptionShowCount(),
-		OptionSpinnerType(GetPresetSpinner(9)),
+		OptionSpinnerType(9),
 	)
 	bar.Reset()
 	for i := 0; i < 10; i++ {

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -196,7 +196,7 @@ func TestSpinnerType(t *testing.T) {
 		OptionSetDescription("indeterminate spinner"),
 		OptionShowIts(),
 		OptionShowCount(),
-		OptionSpinnerType(9),
+		OptionSpinnerType(GetPresetSpinner(9)),
 	)
 	bar.Reset()
 	for i := 0; i < 10; i++ {

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -201,10 +201,53 @@ func TestSpinnerType(t *testing.T) {
 	bar.Reset()
 	for i := 0; i < 10; i++ {
 		time.Sleep(120 * time.Millisecond)
-		bar.Add(1)
+		err := bar.Add(1)
+		if err != nil {
+			t.Errorf("Successfully tested one spinner option can be used.")
+		}
 	}
 	if false {
 		t.Errorf("error")
+	}
+}
+
+func TestSpinnerCustom(t *testing.T) {
+	bar := NewOptions(-1,
+		OptionSetWidth(10),
+		OptionSetDescription("indeterminate spinner"),
+		OptionShowIts(),
+		OptionShowCount(),
+		OptionSpinnerCustom([]string{"🐰", "🐰", "🥕", "🥕"}),
+	)
+	bar.Reset()
+	for i := 0; i < 10; i++ {
+		time.Sleep(120 * time.Millisecond)
+		err := bar.Add(1)
+		if err != nil {
+			t.Errorf("Successfully tested one spinner option can be used.")
+		}
+	}
+	if false {
+		t.Errorf("error")
+	}
+}
+
+func TestSpinnerTypeAndCustom(t *testing.T) {
+	bar := NewOptions(-1,
+		OptionSetWidth(10),
+		OptionSetDescription("indeterminate spinner"),
+		OptionShowIts(),
+		OptionShowCount(),
+		OptionSpinnerCustom([]string{"🐰", "🐰", "🥕", "🥕"}),
+		OptionSpinnerType(9),
+	)
+	bar.Reset()
+	for i := 0; i < 10; i++ {
+		time.Sleep(120 * time.Millisecond)
+		err := bar.Add(1)
+		if err == nil {
+			t.Errorf("Successfully tested both spinner options cannot be used together.")
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

This PR adds a new option to use custom spinners by passing in a `[]string` into `OptionSpinnerCustom`. This allows to use other spinners than one of the 76 preset spinners.
It also returns an `error` in the `Add` func if both options are used. This is not ideal and the correct place would be to make the Option return an error and check this error when creating a new Bar. But since this is also a breaking change (then we have 2 return params) I did not go down that road.