### PR TITLE
fix data race in `Describe`

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -580,6 +580,8 @@ func (p *ProgressBar) Clear() error {
 // Describe will change the description shown before the progress, which
 // can be changed on the fly (as for a slow running process).
 func (p *ProgressBar) Describe(description string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.config.description = description
 	if p.config.invisible {
 		return


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

Since `render` is not thread-safe, and `Describe` is provided to update the description.