### PR TITLE
fix: Protect RenderBlank() and IsFinished() with the lock

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -456,6 +456,9 @@ func (p *ProgressBar) String() string {
 
 // RenderBlank renders the current bar state, you can use this to render a 0% state
 func (p *ProgressBar) RenderBlank() error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	if p.config.invisible {
 		return nil
 	}
@@ -628,6 +631,9 @@ func (p *ProgressBar) ChangeMax64(newMax int64) {
 
 // IsFinished returns true if progress bar is completed
 func (p *ProgressBar) IsFinished() bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	return p.state.finished
 }
 


### PR DESCRIPTION
RenderBlank() calls render() which requires the mutex to be held. IsFinished accesses p.state, which also requires the mutex to be held.