### PR TITLE
Fix SI units calculation and introduce OptionUseIECUnits()

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -1079,12 +1079,12 @@ func average(xs []float64) float64 {
 }
 
 func humanizeBytes(s float64, iec bool) (string, string) {
-	base := 1000.0
 	sizes := []string{" B", " kB", " MB", " GB", " TB", " PB", " EB"}
+	base := 1000.0
 
 	if iec {
-		base = 1024.0
 		sizes = []string{" B", " KiB", " MiB", " GiB", " TiB", " PiB", " EiB"}
+		base = 1024.0
 	}
 
 	if s < 10 {

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -323,14 +323,14 @@ func TestBarSmallBytes(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		bar.Add(1000)
 	}
-	if !strings.Contains(buf.String(), "8.8 kB/95 MB") {
+	if !strings.Contains(buf.String(), "9.0 kB/100 MB") {
 		t.Errorf("wrong string: %s", buf.String())
 	}
 	for i := 1; i < 10; i++ {
 		time.Sleep(10 * time.Millisecond)
 		bar.Add(1000000)
 	}
-	if !strings.Contains(buf.String(), "8.6/95 MB") {
+	if !strings.Contains(buf.String(), "9.0/100 MB") {
 		t.Errorf("wrong string: %s", buf.String())
 	}
 }

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -823,3 +823,19 @@ func TestOptionFullWidth(t *testing.T) {
 		})
 	}
 }
+
+func TestHumanizeBytesSI(t *testing.T) {
+	amount, suffix := humanizeBytes(float64(12.34)*1000*1000, false)
+	assert.Equal(t, "12 MB", fmt.Sprintf("%s%s", amount, suffix))
+
+	amount, suffix = humanizeBytes(float64(56.78)*1000*1000*1000, false)
+	assert.Equal(t, "57 GB", fmt.Sprintf("%s%s", amount, suffix))
+}
+
+func TestHumanizeBytesIEC(t *testing.T) {
+	amount, suffix := humanizeBytes(float64(12.34)*1024*1024, true)
+	assert.Equal(t, "12 MiB", fmt.Sprintf("%s%s", amount, suffix))
+
+	amount, suffix = humanizeBytes(float64(56.78)*1024*1024*1024, true)
+	assert.Equal(t, "57 GiB", fmt.Sprintf("%s%s", amount, suffix))
+}


### PR DESCRIPTION
Problem: currently `progressbar` uses [SI units](https://en.wikipedia.org/wiki/Binary_prefix) by default:

https://github.com/schollz/progressbar/blob/3d122971646c65a9eff62c04531ec131ffb7ce5a/progressbar.go#L1069

...but calculates them with base `1024`, which is not correct and should be `1000` instead.

It's also not possible to choose which the units to use, e.g. the `github.com/dustin/go-humanize` package, for example, allows one to either use [`Bytes()`](https://pkg.go.dev/github.com/dustin/go-humanize#Bytes) or [`IBytes()`](https://pkg.go.dev/github.com/dustin/go-humanize#IBytes).

Solution: fix SI unit base and introduce `OptionUseIECUnits()` option to enable IEC units like `KiB`, `MiB`, etc.