### PR TITLE
fix race condition when changing max

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -615,11 +615,17 @@ func New64(max int64) *ProgressBar {
 
 // GetMax returns the max of a bar
 func (p *ProgressBar) GetMax() int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	return int(p.config.max)
 }
 
 // GetMax64 returns the current max
 func (p *ProgressBar) GetMax64() int64 {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	return p.config.max
 }
 
@@ -635,12 +641,16 @@ func (p *ProgressBar) ChangeMax(newMax int) {
 // but takes in a int64
 // to avoid casting
 func (p *ProgressBar) ChangeMax64(newMax int64) {
+	p.lock.Lock()
+
 	p.config.max = newMax
 
 	if p.config.showBytes {
 		p.config.maxHumanized, p.config.maxHumanizedSuffix = humanizeBytes(float64(p.config.max),
 			p.config.useIECUnits)
 	}
+
+	p.lock.Unlock() // so p.Add can lock
 
 	p.Add(0) // re-render
 }


### PR DESCRIPTION
The Go Race Detector pointed out a data race between
the methods ChangeMax64 and State or GetMax64.
State already takes the lock, but others did not.