### PR TITLE
fix: make elapsedTime option work in non-spinner mode

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -323,7 +323,7 @@ func NewOptions64(max int64, options ...Option) *ProgressBar {
 			width:            40,
 			max:              max,
 			throttleDuration: 0 * time.Nanosecond,
-			elapsedTime:      true,
+			elapsedTime:      max == -1,
 			predictTime:      true,
 			spinnerType:      9,
 			invisible:        false,
@@ -840,7 +840,7 @@ func renderProgressBar(c config, s *state) (int, error) {
 		}
 		rightBrac = rightBracNum.String()
 		fallthrough
-	case c.elapsedTime:
+	case c.elapsedTime || c.showElapsedTimeOnFinish:
 		leftBrac = (time.Duration(time.Since(s.startTime).Seconds()) * time.Second).String()
 	}
 
@@ -944,8 +944,7 @@ func renderProgressBar(c config, s *state) (int, error) {
 			strings.Repeat(c.theme.SaucerPadding, repeatAmount),
 			c.theme.BarEnd,
 			sb.String())
-
-		if s.currentPercent == 100 && c.showElapsedTimeOnFinish {
+		if (s.currentPercent == 100 && c.showElapsedTimeOnFinish) || c.elapsedTime {
 			str = fmt.Sprintf("%s [%s]", str, leftBrac)
 		}
 

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -464,6 +464,37 @@ func TestOptionSetElapsedTime_spinner(t *testing.T) {
 	}
 }
 
+func TestOptionSetElapsedTime(t *testing.T) {
+	buf := strings.Builder{}
+	bar := NewOptions(
+		10,
+		OptionSetElapsedTime(false),
+		OptionSetPredictTime(false),
+		OptionSetWidth(10),
+		OptionSetWriter(&buf),
+	)
+
+	_ = bar.Add(2)
+	result := strings.TrimSpace(buf.String())
+	expect := "20% |██        |"
+
+	if result != expect {
+		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
+	}
+
+	bar.Reset()
+	bar.config.elapsedTime = true
+	buf.Reset()
+
+	_ = bar.Add(7)
+	result = strings.TrimSpace(buf.String())
+	expect = "70% |███████   |  [0s]"
+
+	if result != expect {
+		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
+	}
+}
+
 func TestShowElapsedTimeOnFinish(t *testing.T) {
 	buf := strings.Builder{}
 	bar := NewOptions(10,
@@ -739,9 +770,9 @@ func TestOptionFullWidth(t *testing.T) {
 		{ // 4
 			[]Option{OptionSetPredictTime(false)},
 			"" +
-				"\r  10% |██████                                                          |  " +
-				"\r                                                                          \r" +
-				"\r 100% |████████████████████████████████████████████████████████████████|  ",
+				"\r  10% |██████                                                               |  " +
+				"\r                                                                               \r" +
+				"\r 100% |█████████████████████████████████████████████████████████████████████|  ",
 		},
 		{ // 5
 			[]Option{OptionSetPredictTime(false), OptionShowElapsedTimeOnFinish()},
@@ -795,9 +826,9 @@ func TestOptionFullWidth(t *testing.T) {
 		{ // 12
 			[]Option{OptionShowIts(), OptionShowCount(), OptionSetPredictTime(false)},
 			"" +
-				"\r  10% |████                                           | (10/100, 10 it/s) " +
-				"\r                                                                          \r" +
-				"\r 100% |██████████████████████████████████████████████| (100/100, 50 it/s) ",
+				"\r  10% |█████                                               | (10/100, 10 it/s) " +
+				"\r                                                                               \r" +
+				"\r 100% |███████████████████████████████████████████████████| (100/100, 50 it/s) ",
 		},
 		{ // 13
 			[]Option{OptionShowIts(), OptionShowCount(), OptionSetPredictTime(false), OptionShowElapsedTimeOnFinish()},


### PR DESCRIPTION
Display elapsed time at the end of the bar when elapsedTime is enabled while predictTime is set to false.
To avoid breaking changes, the default value of the elapsed time option is changed to false in non-spinner mode.

Demo:
```
70% |███████   |  [0s]
```