### PR TITLE
fix: only fill the bar for spinners in Finish()

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -494,7 +494,13 @@ func (p *ProgressBar) Reset() {
 
 // Finish will fill the bar to full
 func (p *ProgressBar) Finish() error {
-	return p.Set64(p.config.max)
+	p.lock.Lock()
+	p.state.currentNum = p.config.max
+	if !p.config.ignoreLength {
+		p.state.currentBytes = float64(p.config.max)
+	}
+	p.lock.Unlock()
+	return p.Add(0)
 }
 
 // Exit will exit the bar to keep current state

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -95,7 +95,7 @@ func ExampleOptionClearOnFinish() {
 
 func TestSpinnerClearOnFinish(t *testing.T) {
 	buf := strings.Builder{}
-	bar := NewOptions(-1, OptionShowCount(), OptionShowBytes(true), OptionShowIts(), OptionClearOnFinish(), OptionSetWriter(&buf))
+	bar := NewOptions(-1, OptionSetWidth(100), OptionShowCount(), OptionShowBytes(true), OptionShowIts(), OptionClearOnFinish(), OptionSetWriter(&buf))
 	bar.Reset()
 	time.Sleep(1 * time.Second)
 	bar.Add(10)
@@ -121,7 +121,7 @@ func ExampleProgressBar_Finish() {
 
 func TestSpinnerFinish(t *testing.T) {
 	buf := strings.Builder{}
-	bar := NewOptions(-1, OptionShowCount(), OptionShowBytes(true), OptionShowIts(), OptionSetWriter(&buf))
+	bar := NewOptions(-1, OptionSetWidth(100), OptionShowCount(), OptionShowBytes(true), OptionShowIts(), OptionSetWriter(&buf))
 	bar.Reset()
 	time.Sleep(1 * time.Second)
 	bar.Add(10)

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -93,6 +93,23 @@ func ExampleOptionClearOnFinish() {
 	// Finished
 }
 
+func TestSpinnerClearOnFinish(t *testing.T) {
+	buf := strings.Builder{}
+	bar := NewOptions(-1, OptionShowCount(), OptionShowBytes(true), OptionShowIts(), OptionClearOnFinish(), OptionSetWriter(&buf))
+	bar.Reset()
+	time.Sleep(1 * time.Second)
+	bar.Add(10)
+	time.Sleep(1 * time.Second)
+	bar.Finish()
+	result := buf.String()
+	expect := "" +
+		"\r-  (10 B, 10 B/s, 10 it/s) [1s] " +
+		"\r                                \r"
+	if result != expect {
+		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
+	}
+}
+
 func ExampleProgressBar_Finish() {
 	bar := NewOptions(100, OptionSetWidth(10), OptionShowCount(), OptionShowBytes(true), OptionShowIts())
 	bar.Reset()
@@ -100,6 +117,24 @@ func ExampleProgressBar_Finish() {
 	bar.Finish()
 	// Output:
 	// 100% |██████████| (100/100 B, 100 B/s, 100 it/s)
+}
+
+func TestSpinnerFinish(t *testing.T) {
+	buf := strings.Builder{}
+	bar := NewOptions(-1, OptionShowCount(), OptionShowBytes(true), OptionShowIts(), OptionSetWriter(&buf))
+	bar.Reset()
+	time.Sleep(1 * time.Second)
+	bar.Add(10)
+	time.Sleep(1 * time.Second)
+	bar.Finish()
+	result := buf.String()
+	expect := "" +
+		"\r-  (10 B, 10 B/s, 10 it/s) [1s] " +
+		"\r                                \r" +
+		"\r|  (10 B,  5 B/s, 5 it/s) [2s] "
+	if result != expect {
+		t.Errorf("Render miss-match\nResult: '%s'\nExpect: '%s'\n%+v", result, expect, bar)
+	}
 }
 
 func Example_xOutOfY() {


### PR DESCRIPTION
#187 

I apologize for the oversight in #182 regarding the spinner scenario.

For spinner types, we should not call `Set(max)` in `Finish()` because:

1. The spinner's max is set to the width, so calling `Set(max)` results in incorrect `currentBytes`.
2. In `Add(num)`, if `currentNum < max`, `currentNum = (currentNum + num) % max`, preventing the spinner from finishing.

A simple solution is to update `currentBytes` for non-spinners.