### PR TITLE
add golangci linter in github workflow action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,37 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: false
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
+          args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+run:
+  timeout: 5m
+  exclude-dirs:
+    - vendor
+    - examples
+
+linters:
+  enable:
+    - errcheck
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+linters-settings:
+  gocyclo:
+    min-complexity: 20


### PR DESCRIPTION
Hi @schollz 
Generally, we use automated linters to keep the basic sanity in code base. 
So, I am proposing some basic linters for this repo using GitHub Actions. 
Feel free to suggest changes if needed. 
Following are the basic linters introduced using[ golangci-lint](https://golangci-lint.run) tool.

```
    - errcheck
    - gocyclo
    - gofmt
    - goimports
    - gosimple
    - govet
    - ineffassign
    - staticcheck
    - unused
```

two of the linters are showing some errors. that can be addressed as separate pr. 