### PR TITLE
Feature scrolling detail

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -354,6 +354,10 @@ func NewOptions64(max int64, options ...Option) *ProgressBar {
 		panic("invalid spinner type, must be between 0 and 75")
 	}
 
+	if b.config.maxDetailRow < 0 {
+		panic("invalid max detail row, must be greater than 0")
+	}
+
 	// ignoreLength if max bytes not known
 	if b.config.max == -1 {
 		b.config.ignoreLength = true

--- a/progressbar.go
+++ b/progressbar.go
@@ -314,6 +314,7 @@ func OptionShowDescriptionAtLineEnd() Option {
 }
 
 // OptionSetMaxDetailRow sets the max row of details
+// the row count should be less than the terminal height, otherwise it will not give you the output you want
 func OptionSetMaxDetailRow(row int) Option {
 	return func(p *ProgressBar) {
 		p.config.maxDetailRow = row


### PR DESCRIPTION
This pr is created to resolve https://github.com/schollz/progressbar/issues/176.

You can using this new feature like this:
```go
package main

import (
    "fmt"
    "github.com/schollz/progressbar/v3"
    "time"
)
func main(){
    bar := progressbar.NewOptions(100,progressbar.OptionSetMaxDetailRow(10))
    for i:=1;i<=100;i++{
        bar.AddDetail(fmt.Sprint("processing... ",i))
        if i%10==0{
            bar.Add(10)
        }
        time.Sleep(100*time.Millisecond)
    }
}
```
output would be:
![image](https://github.com/user-attachments/assets/54b0f762-9083-47e9-8b9c-2784bb5d2afc)
in the end:
![image](https://github.com/user-attachments/assets/fe489591-e4d6-4ebb-b161-606428c01a4c)



I use ANSI to solve this problem,which makes it easy for me to control the cursor of terminal. I avoid make the progressbar and detail a whole string to update the detail though it may cause difficulties. According to my own experience, the detail of progress has the update frequency which is much higher then progress bar. So it is better to make the detail update independently.

It works well when the maxDetailRow was set to a value smaller than the height of terminal. I am not sure whether it is needed to provide some function for users to get the max maxDetailRow they can set according to their operate system and the terminal they use.If it is needed, I will be glad to do further development for it.

English is not my mother language, so my writing might be weried. I can explain for anything of this pr if you ask me. Thank you for your patient and dedication.🫶