### PR TITLE
fix: Acquire lock when printing text to fix race condition

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -1153,6 +1153,8 @@ func shouldCacheOutput(pb *ProgressBar) bool {
 }
 
 func Bprintln(pb *ProgressBar, a ...interface{}) (int, error) {
+	pb.lock.Lock()
+	defer pb.lock.Unlock()
 	if !shouldCacheOutput(pb) {
 		return fmt.Fprintln(pb.config.writer, a...)
 	} else {
@@ -1161,6 +1163,8 @@ func Bprintln(pb *ProgressBar, a ...interface{}) (int, error) {
 }
 
 func Bprintf(pb *ProgressBar, format string, a ...interface{}) (int, error) {
+	pb.lock.Lock()
+	defer pb.lock.Unlock()
 	if !shouldCacheOutput(pb) {
 		return fmt.Fprintf(pb.config.writer, format, a...)
 	} else {


### PR DESCRIPTION
Hey!

I've been testing the new `Bprintf` and `Bprintln` functions, and have found a race condition.

If text is printed at the same time as `Write` is called, there's a chance that some of the text will not be printed. This is because `bytes.Buffer` is not thread-safe. In my testing, acquiring a lock in `Bprintf` and `Bprintln` fixes the issue.