### PR TITLE
feat: add an HTTP server to enable users to monitor status updates via status bars or other UI components.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,3 @@ require (
 )
 
 go 1.22
-
-toolchain go1.22.10

--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 )
 
 go 1.22
+
+toolchain go1.22.10


### PR DESCRIPTION
Users now can monitor status updates in status bar via `xbar` extension or other UI components.

demo `xbar` extension:

`progress_monitor.1s.sh`:

```shell
#!/bin/bash
curl -s "http://x.x.x.x:19999/desc"
```

status bar demo:
<img width="238" alt="demo" src="https://github.com/user-attachments/assets/de9dccbb-7f36-4629-bc81-4ef4779197e5">

