### PR TITLE
Fix terminal width when stdout is redirected

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -1192,7 +1192,7 @@ func renderProgressBar(c config, s *state) (int, error) {
 	}
 
 	if c.fullWidth && !c.ignoreLength {
-		width, err := termWidth()
+		width, err := termWidth(c.writer)
 		if err != nil {
 			width = 80
 		}
@@ -1480,12 +1480,15 @@ func logn(n, b float64) float64 {
 
 // termWidth function returns the visible width of the current terminal
 // and can be redefined for testing
-var termWidth = func() (width int, err error) {
-	width, _, err = term.GetSize(int(os.Stdout.Fd()))
-	if err == nil {
-		return width, nil
+var termWidth = func(w io.Writer) (width int, err error) {
+	if f, ok := w.(*os.File); ok {
+		width, _, err = term.GetSize(int(f.Fd()))
+		if err == nil {
+			return width, nil
+		}
+	} else {
+		err = errors.New("output is not a *os.File")
 	}
-
 	return 0, err
 }
 

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	termWidth = func() (int, error) {
+	termWidth = func(w io.Writer) (int, error) {
 		return 0, os.ErrPermission
 	}
 	os.Exit(m.Run())


### PR DESCRIPTION
Instead of always checking stdout, check the actually configured output file. Fixes cases when stdout is redirected to a file or /dev/null, but stderr remains connected to the terminal.

It was previously fixed in #91, but was broken in #156.