### PR TITLE
Remove hardcoded choice

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -979,14 +979,12 @@ func (p *ProgressBar) render() error {
 func (p *ProgressBar) lengthUnknown() {
 	p.config.ignoreLength = true
 	p.config.max = int64(p.config.width)
-	p.config.predictTime = false
 }
 
 // lengthKnown sets the progress bar to do not ignore the length
 func (p *ProgressBar) lengthKnown(max int64) {
 	p.config.ignoreLength = false
 	p.config.max = max
-	p.config.predictTime = true
 }
 
 // State returns the current state


### PR DESCRIPTION
Hi, hello! Maybe this is not a fix but let's have in mind this situation. 

When I initialize the bar I can set a config option to not show me the predicted time.
But if I change the max value of the bar it will force update that config and it will leave me no other choice other than to create a new bar.