### PR TITLE
Always call `bar.Finish()` in `Reader`

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -1418,7 +1418,7 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 // Close the reader when it implements io.Closer
 func (r *Reader) Close() (err error) {
 	if closer, ok := r.Reader.(io.Closer); ok {
-		return closer.Close()
+		err = closer.Close()
 	}
 	r.bar.Finish()
 	return


### PR DESCRIPTION
In the current implementation, `bar.Finish()` is never called if the underlying `io.Reader` also implements `io.Closer`.