### PR TITLE
fix: flickering on powershell

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -1373,6 +1374,9 @@ func clearProgressBar(c config, s state) error {
 	// fill the empty content
 	// to overwrite the progress bar and jump
 	// back to the beginning of the line
+	if runtime.GOOS == "windows" {
+		return writeString(c, "\r")
+	}
 	str := fmt.Sprintf("\r%s\r", strings.Repeat(" ", s.maxLineWidth))
 	return writeString(c, str)
 	// the following does not show correctly if the previous line is longer than subsequent line


### PR DESCRIPTION
## Fix Windows progress bar flickering issue

### Problem
On Windows platforms, the progress bar exhibits significant flickering during updates due to differences in how Windows console handles carriage return (`\r`) characters compared to Unix/Linux systems.

### Root Cause
The issue is in the `clearProgressBar` function where multiple `\r` operations are used:
```go
str := fmt.Sprintf("\r%s\r", strings.Repeat(" ", s.maxLineWidth))
```

Windows console doesn't handle multiple `\r` operations as reliably as Unix/Linux terminals, causing visual artifacts.

### Solution
- Added platform-specific handling for Windows
- Use minimal `\r` operation on Windows instead of full-line overwrite
- Maintain backward compatibility for Unix/Linux systems

### Changes
- Added `runtime` import for platform detection
- Modified `clearProgressBar` function to use Windows-specific handling
- Simplified cursor control on Windows to reduce flickering

### Testing
- ✅ Tested on Windows PowerShell
- ✅ Tested on Windows Terminal  
- ✅ Verified no regression on Unix/Linux systems

### Related Issue
Closes #219