### PR TITLE
fix: trailing residual characters in ANSI mode

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -1357,6 +1357,10 @@ func renderProgressBar(c config, s *state) (int, error) {
 		str = colorstring.Color(str)
 	}
 
+	if c.useANSICodes {
+		str = str + "\033[0K"
+	}
+
 	s.rendered = str
 
 	return getStringWidth(c, str, false), writeString(c, str)


### PR DESCRIPTION
Fixes #124.

In ANSI mode, when the total line width decreases, trailing characters from the previously rendered line are not cleared.

This is a regression, introduced in commit [df9a997f0a], as described in #124.

Thanks to @NathanBaulch for reporting the issue and the root cause 👏🏻 