### PR TITLE
Added OptionSetSpinnerColorCode to support color codes for spinners.

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -1304,7 +1304,7 @@ func renderProgressBar(c config, s *state) (int, error) {
 			s.spinnerIdx = (s.spinnerIdx + 1) % len(selectedSpinner)
 		}
 		// if set add spinner color code
-		if c.spinnerColorCode != "" {
+		if c.spinnerColorCode != "" && c.colorCodes {
 			spinner = "[" + c.spinnerColorCode + "]" + spinner + "[reset]"
 		}
 		if c.elapsedTime {

--- a/progressbar.go
+++ b/progressbar.go
@@ -81,6 +81,8 @@ type config struct {
 	colorCodes bool
 	// custom colors to use for colorCodes
 	customColors map[string]string
+	// color to apply to spinner
+	spinnerColorCode string
 
 	// show rate of change in kB/sec or MB/sec
 	showBytes bool
@@ -287,6 +289,13 @@ func OptionEnableColorCodes(colorCodes bool) Option {
 func OptionSetCustomColorCodes(customColors map[string]string) Option {
 	return func(p *ProgressBar) {
 		p.config.customColors = customColors
+	}
+}
+
+// OptionSetSpinnerColorCode sets color code for spinner
+func OptionSetSpinnerColorCode(colorCode string) Option {
+	return func(p *ProgressBar) {
+		p.config.spinnerColorCode = colorCode
 	}
 }
 
@@ -1293,6 +1302,10 @@ func renderProgressBar(c config, s *state) (int, error) {
 			// if the spinner is changed according to the number render was called
 			spinner = selectedSpinner[s.spinnerIdx]
 			s.spinnerIdx = (s.spinnerIdx + 1) % len(selectedSpinner)
+		}
+		// if set add spinner color code
+		if c.spinnerColorCode != "" {
+			spinner = "[" + c.spinnerColorCode + "]" + spinner + "[reset]"
 		}
 		if c.elapsedTime {
 			if c.showDescriptionAtLineEnd {


### PR DESCRIPTION
Added OptionSetSpinnerColorCode to pass in color code for spinner - is ignored if not set or if color codes is not enabled. It's not terribly visible but more of a completeness feature.

Example Usage:

```
	bar := progressbar.NewOptions64(
		-1,
		progressbar.OptionSetDescription("[Counter Example] Received"),
		progressbar.OptionSetWidth(10),
		progressbar.OptionEnableColorCodes(true),
		progressbar.OptionSetSpinnerColorCode("red"),
		progressbar.OptionThrottle(65*time.Millisecond),
		progressbar.OptionShowCount(),
		progressbar.OptionSpinnerType(14),
		progressbar.OptionFullWidth(),
		progressbar.OptionSetRenderBlankState(true),
	)

	c := make(chan int)

	go func(notify chan<- int) {
		defer close(notify)
		for i := 0; i < 100; i++ {
			c <- i
			time.Sleep(time.Millisecond * 100)
		}
	}(c)

	for v := range c {
		bar.Add(v)
	}
```