### PR TITLE
feat: add OptionSetStartingBytes for resumed transfers

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -55,10 +55,11 @@ type state struct {
 	counterLastTenRates []float64
 	spinnerIdx          int // the index of spinner
 
-	maxLineWidth int
-	currentBytes float64
-	finished     bool
-	exit         bool // Progress bar exit halfway
+	maxLineWidth  int
+	currentBytes  float64
+	startingBytes float64 // units already done before the bar started; excluded from the rate
+	finished      bool
+	exit          bool // Progress bar exit halfway
 
 	details []string // details to show,only used when detail row is set to more than 0
 
@@ -407,6 +408,19 @@ func OptionShowDescriptionAtLineEnd() Option {
 func OptionSetMaxDetailRow(row int) Option {
 	return func(p *ProgressBar) {
 		p.config.maxDetailRow = row
+	}
+}
+
+// OptionSetStartingBytes seeds the bar at an already-completed position, for
+// resuming a partial transfer. The percentage and ETA start from num, but those
+// bytes are excluded from the reported rate — analogous to Python tqdm's
+// initial=. Without this, the only way to reflect prior progress is Set(num),
+// which feeds the jump into the rolling-rate window and inflates the speed.
+func OptionSetStartingBytes(num int64) Option {
+	return func(p *ProgressBar) {
+		p.state.currentNum = num
+		p.state.currentBytes = float64(num)
+		p.state.startingBytes = float64(num)
 	}
 }
 
@@ -1035,7 +1049,7 @@ func (p *ProgressBar) State() State {
 	if p.state.currentNum > 0 {
 		s.SecondsLeft = s.SecondsSince / float64(p.state.currentNum) * (float64(p.config.max) - float64(p.state.currentNum))
 	}
-	s.KBsPerSecond = float64(p.state.currentBytes) / 1024.0 / s.SecondsSince
+	s.KBsPerSecond = (float64(p.state.currentBytes) - p.state.startingBytes) / 1024.0 / s.SecondsSince
 	s.Description = p.config.description
 	return s
 }
@@ -1199,7 +1213,7 @@ func renderProgressBar(c config, s *state) (int, error) {
 		// if no average samples, or if finished,
 		// then average rate should be the total rate
 		if t := time.Since(s.startTime).Seconds(); t > 0 {
-			averageRate = s.currentBytes / t
+			averageRate = (s.currentBytes - s.startingBytes) / t
 		} else {
 			averageRate = 0
 		}

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -431,6 +431,29 @@ func TestState(t *testing.T) {
 	}
 }
 
+func TestStartingBytes(t *testing.T) {
+	bar := NewOptions64(100, OptionSetWidth(10), OptionSetStartingBytes(80))
+	s := bar.State()
+	if s.CurrentBytes != 80 {
+		t.Errorf("expected CurrentBytes 80, got %v", s.CurrentBytes)
+	}
+	if s.CurrentPercent != 0.8 {
+		t.Errorf("expected CurrentPercent 0.8, got %v", s.CurrentPercent)
+	}
+
+	// Transfer 10 more over ~0.2s: the rate must reflect only those 10 units,
+	// not the 80 seeded ones. Without the offset the fallback rate would be
+	// 90/0.2 = 450/s; with it, ~50/s.
+	bar = NewOptions64(100, OptionSetWidth(10), OptionSetStartingBytes(80), OptionSetWriter(io.Discard))
+	bar.Add(0) // start the clock at the seeded position
+	time.Sleep(200 * time.Millisecond)
+	bar.Add(10)
+	s = bar.State()
+	if rate := s.KBsPerSecond * 1024; rate > 200 {
+		t.Errorf("rate should exclude seeded bytes, got %v/s", rate)
+	}
+}
+
 func ExampleOptionSetRenderBlankState() {
 	NewOptions(10, OptionSetWidth(10), OptionSetRenderBlankState(true))
 	// Output:


### PR DESCRIPTION
Closes #231.

Seeds the bar at an already-completed position for resumed transfers (e.g. partially-downloaded files), like Python tqdm's `initial=`. The seeded bytes count toward percentage and ETA but are excluded from the reported rate.

## Why
Today, the only way to reflect prior progress is `Set(current)`. That feeds the jump into the rolling-rate window (`counterNumSinceLast` over ~0.5s), so the first render shows a wildly inflated speed until the window decays. The fallback rate path (`currentBytes / elapsed`, used when the rolling window has no samples yet) has the same problem.

## What

```go
bar := progressbar.NewOptions64(
    totalBytes,
    progressbar.OptionShowBytes(true),
    progressbar.OptionSetStartingBytes(alreadyOnDisk), // <-- new
)
// subsequent bar.Set(n) / bar.Add(delta) show a truthful rate
```

Under the hood: a new `startingBytes` field on `state` records how much was completed before the bar started. Both rate paths (rolling window and the pre-window fallback) subtract it, as does `State().KBsPerSecond`.

## Test
`TestStartingBytes` verifies both invariants:
- `CurrentBytes` / `CurrentPercent` start at the seeded position.
- After transferring 10 units over ~200ms with 80 seeded, `KBsPerSecond*1024` is well under 200/s (would be ~450/s without the offset).