### PR TITLE
Add OptionSetRateAveragingWindow for time-windowed rate averaging

### DIFF
--- a/progressbar.go
+++ b/progressbar.go
@@ -53,6 +53,7 @@ type state struct {
 	counterTime         time.Time
 	counterNumSinceLast int64
 	counterLastTenRates []float64
+	counterRateTimes    []time.Time
 	spinnerIdx          int // the index of spinner
 
 	maxLineWidth  int
@@ -107,6 +108,13 @@ type config struct {
 
 	// minimum time to wait in between updates
 	throttleDuration time.Duration
+
+	// rateAveragingWindow, when greater than zero, averages the rate (and thus
+	// the predicted time remaining) over the samples collected within this
+	// trailing time window instead of over the last few samples. A longer
+	// window yields a smoother, more stable estimate for long-running tasks
+	// whose rate fluctuates.
+	rateAveragingWindow time.Duration
 
 	// clear bar once finished
 	clearOnFinish bool
@@ -311,6 +319,19 @@ func OptionSetElapsedTime(elapsedTime bool) Option {
 func OptionSetPredictTime(predictTime bool) Option {
 	return func(p *ProgressBar) {
 		p.config.predictTime = predictTime
+	}
+}
+
+// OptionSetRateAveragingWindow sets the trailing time window used to average
+// the rate of progress. By default the bar averages over its last few samples,
+// which can make the reported rate and predicted time remaining jumpy for
+// long-running tasks. Passing a window (for example, time.Minute) averages
+// over every sample collected within that trailing window instead, producing a
+// steadier estimate. A window of zero (the default) keeps the original
+// behavior.
+func OptionSetRateAveragingWindow(window time.Duration) Option {
+	return func(p *ProgressBar) {
+		p.config.rateAveragingWindow = window
 	}
 }
 
@@ -737,11 +758,13 @@ func (p *ProgressBar) Add64(num int64) error {
 	// reset the countdown timer every second to take rolling average
 	p.state.counterNumSinceLast += num
 	if time.Since(p.state.counterTime).Seconds() > 0.5 {
-		p.state.counterLastTenRates = append(p.state.counterLastTenRates, float64(p.state.counterNumSinceLast)/time.Since(p.state.counterTime).Seconds())
-		if len(p.state.counterLastTenRates) > 10 {
-			p.state.counterLastTenRates = p.state.counterLastTenRates[1:]
-		}
-		p.state.counterTime = time.Now()
+		now := time.Now()
+		rate := float64(p.state.counterNumSinceLast) / time.Since(p.state.counterTime).Seconds()
+		p.state.counterLastTenRates = append(p.state.counterLastTenRates, rate)
+		p.state.counterRateTimes = append(p.state.counterRateTimes, now)
+		p.state.counterLastTenRates, p.state.counterRateTimes = trimRateSamples(
+			p.state.counterLastTenRates, p.state.counterRateTimes, p.config.rateAveragingWindow, now)
+		p.state.counterTime = now
 		p.state.counterNumSinceLast = 0
 	}
 
@@ -1529,6 +1552,31 @@ func (p *ProgressBar) Read(b []byte) (n int, err error) {
 func (p *ProgressBar) Close() (err error) {
 	err = p.Finish()
 	return
+}
+
+// maxLegacyRateSamples is the number of recent rate samples averaged when no
+// rate-averaging window is configured (see OptionSetRateAveragingWindow).
+const maxLegacyRateSamples = 10
+
+// trimRateSamples discards rate samples that fall outside the averaging window.
+// rates and times are parallel slices ordered oldest to newest, with times[i]
+// recording when rates[i] was collected. When window is greater than zero, only
+// samples collected within the trailing window relative to now are kept (the
+// most recent sample is always retained). Otherwise it keeps at most the last
+// maxLegacyRateSamples samples.
+func trimRateSamples(rates []float64, times []time.Time, window time.Duration, now time.Time) ([]float64, []time.Time) {
+	if window > 0 {
+		cutoff := now.Add(-window)
+		drop := 0
+		for drop < len(times)-1 && times[drop].Before(cutoff) {
+			drop++
+		}
+		return rates[drop:], times[drop:]
+	}
+	if len(rates) > maxLegacyRateSamples {
+		return rates[len(rates)-maxLegacyRateSamples:], times[len(times)-maxLegacyRateSamples:]
+	}
+	return rates, times
 }
 
 func average(xs []float64) float64 {

--- a/progressbar_test.go
+++ b/progressbar_test.go
@@ -1267,3 +1267,77 @@ func TestStartHTTPServer(t *testing.T) {
 		t.Errorf("shutdown server failed: %v", err)
 	}
 }
+
+func TestTrimRateSamples(t *testing.T) {
+	base := time.Now()
+	times := []time.Time{
+		base.Add(-10 * time.Second),
+		base.Add(-5 * time.Second),
+		base.Add(-2 * time.Second),
+		base,
+	}
+	rates := []float64{1, 2, 3, 4}
+
+	clone := func() ([]float64, []time.Time) {
+		return append([]float64{}, rates...), append([]time.Time{}, times...)
+	}
+
+	// A 6s window keeps only the samples collected within the last 6 seconds.
+	r, tt := clone()
+	gotRates, gotTimes := trimRateSamples(r, tt, 6*time.Second, base)
+	if len(gotRates) != 3 || gotRates[0] != 2 {
+		t.Errorf("window trim: expected 3 samples starting at 2, got %v", gotRates)
+	}
+	if len(gotTimes) != len(gotRates) {
+		t.Errorf("window trim: rates/times length mismatch: %d vs %d", len(gotRates), len(gotTimes))
+	}
+
+	// A window shorter than the gap between samples keeps only the newest sample.
+	r, tt = clone()
+	gotRates, _ = trimRateSamples(r, tt, time.Nanosecond, base)
+	if len(gotRates) != 1 || gotRates[0] != 4 {
+		t.Errorf("tiny window: expected only the newest sample 4, got %v", gotRates)
+	}
+
+	// Without a window, at most maxLegacyRateSamples samples are kept.
+	manyRates := make([]float64, maxLegacyRateSamples+5)
+	manyTimes := make([]time.Time, maxLegacyRateSamples+5)
+	for i := range manyRates {
+		manyRates[i] = float64(i)
+		manyTimes[i] = base.Add(time.Duration(i) * time.Second)
+	}
+	gotRates, _ = trimRateSamples(manyRates, manyTimes, 0, base)
+	if len(gotRates) != maxLegacyRateSamples {
+		t.Errorf("legacy trim: expected %d samples, got %d", maxLegacyRateSamples, len(gotRates))
+	}
+	if gotRates[0] != 5 {
+		t.Errorf("legacy trim: expected to keep the newest samples, first kept = %v", gotRates[0])
+	}
+}
+
+func TestRateAveragingWindow(t *testing.T) {
+	forceSamples := func(bar *ProgressBar, n int) {
+		for i := 0; i < n; i++ {
+			// backdate the counter so each Add records a new rate sample
+			bar.state.counterTime = time.Now().Add(-time.Second)
+			if err := bar.Add(1); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Without a window the number of retained rate samples is capped.
+	legacy := NewOptions(1000000, OptionSetWriter(io.Discard))
+	forceSamples(legacy, maxLegacyRateSamples+15)
+	if got := len(legacy.state.counterLastTenRates); got != maxLegacyRateSamples {
+		t.Errorf("legacy: expected %d retained rate samples, got %d", maxLegacyRateSamples, got)
+	}
+
+	// With a window covering the whole test, every sample is retained, so the
+	// count exceeds the legacy cap.
+	windowed := NewOptions(1000000, OptionSetWriter(io.Discard), OptionSetRateAveragingWindow(time.Hour))
+	forceSamples(windowed, maxLegacyRateSamples+15)
+	if got := len(windowed.state.counterLastTenRates); got <= maxLegacyRateSamples {
+		t.Errorf("windowed: expected more than %d retained samples, got %d", maxLegacyRateSamples, got)
+	}
+}


### PR DESCRIPTION
This addresses #208.

## Problem

The reported rate and the predicted time remaining are derived from a rolling average of the last few rate samples (a fixed cap of 10 samples). For long-running tasks whose throughput varies over time, that short window makes the rate and ETA jumpy, and a brief burst or stall can noticeably skew the estimate.

## Change

Adds a new option, `OptionSetRateAveragingWindow(window time.Duration)`, which averages the rate over every sample collected within a trailing time window rather than over a fixed number of the most recent samples:

```go
bar := progressbar.NewOptions64(
    total,
    progressbar.OptionSetRateAveragingWindow(time.Minute),
)
```

A longer window produces a smoother, more stable rate and ETA for jobs that run for a while.

## Compatibility

The default is a zero window, which preserves the existing behavior exactly (keep the last 10 samples). Nothing changes unless a caller opts in. The sampling cadence is unchanged; only the retention/trim step is affected.

## Implementation notes

- Rate samples now carry a parallel timestamp slice so the trim step can drop samples outside the configured window.
- The trim logic is extracted into a small pure helper, `trimRateSamples`, which handles both the windowed and the legacy fixed-count paths.

## Tests

- `TestTrimRateSamples` covers the helper deterministically: windowed trimming, a window smaller than the sample gap (keeps only the newest), and the legacy fixed-count cap.
- `TestRateAveragingWindow` drives `Add` and verifies the legacy path caps retained samples while the windowed path retains more.

`go test ./...`, `go vet`, and `gofmt` all pass.